### PR TITLE
Fix LinkedIn URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </div>
 
 <div id="badges" align="center">
-  <a href="www.linkedin.com/in/rawnsh5">
+  <a href="https://linkedin.com/in/rawnsh5">
     <img src="https://img.shields.io/badge/LinkedIn-blue?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn Badge"/>
   </a>
   <a href="https://twitter.com/rawnsh5">


### PR DESCRIPTION
External URL should start using `protocol`

http:// or https://